### PR TITLE
Adding support for individual segment control

### DIFF
--- a/SevSeg/SevSeg.cpp
+++ b/SevSeg/SevSeg.cpp
@@ -219,9 +219,9 @@ void SevSeg::DisplayString(char* toDisplay, byte DecAposColon)
 		//This could be cleaned up a bit but it works
 		//displayCharacter(toDisplay[digit-1]); //Now display this digit
 		// displayArray (defined in SevSeg.h) decides which segments are turned on for each number or symbol
-		unsigned char characterToDisplay = toDisplay[digit-1];
-		if (characterToDisplay & 0x80)
-		{	// Could remake a segmentPins[] array to get this in a for loop
+		char characterToDisplay = toDisplay[digit-1];
+		if (characterToDisplay & 0x80)	// bit 7 enables bit-per-segment control
+		{	// Each bit of characterToDisplay turns on a single segment (from A-to-G)
 			if (characterToDisplay & 0x01) digitalWrite(segmentA, SegOn);
 			if (characterToDisplay & 0x02) digitalWrite(segmentB, SegOn);
 			if (characterToDisplay & 0x04) digitalWrite(segmentC, SegOn);


### PR DESCRIPTION
This is what I've come up with to support [individual segment control](https://github.com/sparkfun/Serial7SegmentDisplay/wiki/Special-Commands#wiki-individual) on the S7S. A method similar to what the firmware had been doing before the SevSeg library.

If the msb of a characterToDisplay is set, it goes into bit-per-segment display mode. Each of the lower 7 bits correspond to a segment on the digit.

As the characterArray[] segment map in SevSeg.h is only defined up to a value of 127 anyway, this should only add to the DisplayString method's functionality.
