### PR TITLE
DisplayString() using no delays

### DIFF
--- a/src/SevSeg.cpp
+++ b/src/SevSeg.cpp
@@ -178,6 +178,8 @@ void SevSeg::SetBrightness(byte percentBright)
 {
 	//Error check brightnessLevel
 	if(percentBright > 100){brightness = 100;}
+  else if(percentBright < 1){brightness = 1;}
+  else{brightness = percentBright;}
   
   brightnessDelay = (100-brightness)*numberOfDigits*100/brightness;
 }
@@ -221,7 +223,7 @@ void SevSeg::DisplayString(char* toDisplay, byte DecAposColon)
     else if(digit == numberOfDigits)
     {
       turnDigitOff(numberOfDigits-1);
-      turnDigitOn(toDisplay, numberOfDigits);
+      turnDigitOn(toDisplay, numberOfDigits, DecAposColon);
       digit = digitColon != 255 || digitApostrophe != 255 ? digit+1 : 0;
       previousMicros = micros();
       timer = brightness; //Display this digit for a fraction of a second (between 1us and 5000us, 500-2000 is pretty good)
@@ -252,7 +254,7 @@ void SevSeg::DisplayString(char* toDisplay, byte DecAposColon)
         {
           turnDigitOff(digit-1);
         }
-        turnDigitOn(toDisplay, digit);
+        turnDigitOn(toDisplay, digit, DecAposColon);
         previousMicros = micros();
         timer = brightness; //Display this digit for a fraction of a second (between 1us and 5000us, 500-2000 is pretty good)
       }
@@ -290,8 +292,9 @@ void SevSeg::turnDigitOff(byte digit)
       break;
     //This only currently works for 4 digits
   }
+}
 
-void SevSeg::turnDigitOn(char* toDisplay, byte digit)
+void SevSeg::turnDigitOn(char* toDisplay, byte digit, byte DecAposColon)
 {
  switch(digit) 
   {

--- a/src/SevSeg.h
+++ b/src/SevSeg.h
@@ -117,7 +117,7 @@ const uint8_t characterArray[] PROGMEM = {
   0b0000000, // 94  '^'  NO DISPLAY
   0b0001000, // 95  '_'
   0b0000010, // 96  '`'
-  0b1110111, // 97  'a' SAME AS CAP
+  0b1111101, // 97  'a'
   0b0011111, // 98  'b' SAME AS CAP
   0b0001101, // 99  'c'
   0b0111101, // 100 'd' SAME AS CAP

--- a/src/SevSeg.h
+++ b/src/SevSeg.h
@@ -17,17 +17,6 @@
 
 #define BLANK 16 //Special character that turns off all segments (we chose 16 as it is the first spot that has this)
 
-// framePeriod controls the length of time between display refreshes
-// It's also closely linked to the brightness setting
-#define FRAMEPERIOD 2000 
-//Total amount of time (in microseconds) for the display frame. 1,000us is roughly 1000Hz update rate
-//A framePeriod of:
-//5000 is flickery
-//3000 has good low brightness vs full brightness
-//2000 works well
-//500 seems like the low brightness is pretty bright, not great
-
-
 //This is the combined array that contains all the segment configurations for many different characters and symbols
 const uint8_t characterArray[] PROGMEM = {
 //  ABCDEFG  Segments      7-segment map:
@@ -180,6 +169,8 @@ private:
   //Private Functions
   void displayCharacter(byte characterToDisplay); //Illuminates the correct segments
   void SplitNumber(int);
+  void turnDigitOff(byte digit);
+  void turnDigitOn(char* toDisplay, byte digit);
 
   //Private Variables
   boolean mode, DigitOn, DigitOff, SegOn, SegOff;
@@ -190,7 +181,8 @@ private:
   
   byte numberOfDigits;
   
-  unsigned int brightnessDelay;
+  unsigned int brightness, brightnessDelay;
+  unsigned long previousMicros, timer;
 
   byte DigitPins[4];
   byte SegmentPins[8];

--- a/src/SevSeg.h
+++ b/src/SevSeg.h
@@ -170,7 +170,7 @@ private:
   void displayCharacter(byte characterToDisplay); //Illuminates the correct segments
   void SplitNumber(int);
   void turnDigitOff(byte digit);
-  void turnDigitOn(char* toDisplay, byte digit);
+  void turnDigitOn(char* toDisplay, byte digit, byte DecAposColon);
 
   //Private Variables
   boolean mode, DigitOn, DigitOff, SegOn, SegOff;


### PR DESCRIPTION
The DisplayString function has been updated to eliminate any delay.
Rather than iterating through the digits in a for loop every time the
function is called, this approach iterates on a static variable only
after a given time has elapsed regardless of how often the function is
called. In order to get this working while preserving all other
functionality (brightness, different numbers/types of digits, etc.) the
function has become a little harder to follow. Here it is in a nutshell.
/********************************************************************/
static byte digit = 0;
if (time is up) //do something
if (digit == numberOfDigits +1)   //only used when there's a colon
and/or apos
turn off the final digit        //the one equal to numberOfDigits
turn on the colon and/or apos
digit = 0                       //reset static variable for the next
cycle
set timer to brightness
else if (digit == numberOfDigits)
turn off previous digit
turn on final digit             //the one equal to numberOfDigits
if (there's a colon) digit++    //is there a colon/apos?
else digit=0                       //or should we reset?
set timer to brightness
else
if (digit == 0)
if (there's a colon/apos)
turn off colon/apos
else
turn off the final digit    //the one equal to numberOfDigits
set timer to brightnessDelay
else
if (digit != 1);              //digits that can be iterated upon
normally
turn off the previous digit
turn on the current digit
set timer to brightness
digit++;
else do nothing until time is up
/********************************************************************/
The sections for turning digits/segments on and off have been broken out
into

void turnDigitOff(byte digit);
void turnDigitOn(char* toDisplay, byte digit);

Variables for keeping track of time have also been added.

unsigned long previousMicros, timer;

I hadn't originally intended to edit SetBrightness() but because the new
approach entirely foregoes the FRAMEPERIOD, I had to find a workaround.
I think it makes the code a bit cleaner and I haven't noticed any kind
of flickering but it's only been tested properly on a 4-digit display.